### PR TITLE
Made edits to HPForm for OnDamage saves

### DIFF
--- a/GroupProject/AddStatusEffect.Designer.cs
+++ b/GroupProject/AddStatusEffect.Designer.cs
@@ -51,13 +51,13 @@
             StatusDuration = new NumericUpDown();
             SvEndOfTurn = new CheckBox();
             SavingThrowBox = new GroupBox();
+            SaveStatBox = new TextBox();
+            SaveStatLabel = new Label();
             SaveDCLabel = new Label();
             SaveDCBox = new NumericUpDown();
             AddStatusButton = new Button();
             SvOnDmg = new CheckBox();
             SvStartOfTurn = new CheckBox();
-            SaveStatLabel = new Label();
-            SaveStatBox = new TextBox();
             ConditionsBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)StatusDuration).BeginInit();
             SavingThrowBox.SuspendLayout();
@@ -289,6 +289,7 @@
             StatusDuration.Name = "StatusDuration";
             StatusDuration.Size = new Size(55, 27);
             StatusDuration.TabIndex = 6;
+            StatusDuration.Value = new decimal(new int[] { 1, 0, 0, 0 });
             // 
             // SvEndOfTurn
             // 
@@ -317,6 +318,22 @@
             SavingThrowBox.TabStop = false;
             SavingThrowBox.Text = "Saving Throws";
             // 
+            // SaveStatBox
+            // 
+            SaveStatBox.Location = new Point(79, 26);
+            SaveStatBox.Name = "SaveStatBox";
+            SaveStatBox.Size = new Size(40, 27);
+            SaveStatBox.TabIndex = 13;
+            // 
+            // SaveStatLabel
+            // 
+            SaveStatLabel.AutoSize = true;
+            SaveStatLabel.Location = new Point(6, 30);
+            SaveStatLabel.Name = "SaveStatLabel";
+            SaveStatLabel.Size = new Size(73, 20);
+            SaveStatLabel.TabIndex = 12;
+            SaveStatLabel.Text = "Save Stat:";
+            // 
             // SaveDCLabel
             // 
             SaveDCLabel.AutoSize = true;
@@ -332,6 +349,7 @@
             SaveDCBox.Name = "SaveDCBox";
             SaveDCBox.Size = new Size(40, 27);
             SaveDCBox.TabIndex = 10;
+            SaveDCBox.Value = new decimal(new int[] { 10, 0, 0, 0 });
             // 
             // AddStatusButton
             // 
@@ -367,22 +385,6 @@
             SvStartOfTurn.TabIndex = 8;
             SvStartOfTurn.Text = "Start of Turn";
             SvStartOfTurn.UseVisualStyleBackColor = true;
-            // 
-            // SaveStatLabel
-            // 
-            SaveStatLabel.AutoSize = true;
-            SaveStatLabel.Location = new Point(6, 30);
-            SaveStatLabel.Name = "SaveStatLabel";
-            SaveStatLabel.Size = new Size(73, 20);
-            SaveStatLabel.TabIndex = 12;
-            SaveStatLabel.Text = "Save Stat:";
-            // 
-            // SaveStatBox
-            // 
-            SaveStatBox.Location = new Point(79, 26);
-            SaveStatBox.Name = "SaveStatBox";
-            SaveStatBox.Size = new Size(40, 27);
-            SaveStatBox.TabIndex = 13;
             // 
             // AddStatusEffect
             // 

--- a/GroupProject/AddStatusEffect.cs
+++ b/GroupProject/AddStatusEffect.cs
@@ -79,7 +79,7 @@ namespace GroupProject
             { unconscious = true; }
 
             //Call constructor
-            StatusEffect newEffect = new StatusEffect(name, duration, sot, eot, onDmg, saveType, saveDC,otherEffects, blinded,
+            StatusEffect newEffect = new StatusEffect(name, duration, sot, eot, onDmg, saveType, saveDC, otherEffects, blinded,
                                                       charmed, deafened, frightened, grappled, incapacitated,
                                                       invisible, paralyzed, petrified, poisoned, prone,
                                                       restrained, stunned, unconscious);

--- a/GroupProject/Form1.cs
+++ b/GroupProject/Form1.cs
@@ -1003,16 +1003,37 @@ namespace GroupProject
             Creature thisGuy = (Creature)creatureListBox.SelectedItem;
             //Search the creature's status effect list and compile its EoT saves
             saves = findEoTSaves(thisGuy.StatusEffects);
+
             //If selected creature has a saving throw to make at the end of the turn, display alert
             if(saves != "")
             {
                 MessageBox.Show($"{thisGuy.GetName()} needs to make the following saving throw(s):\n" + saves);
             }
-            //Progess the turn to the next creature
-                //Use a try/catch to set the index back to zero if it goes out of range
-            //Search the new creature's status effect list and compile its SoT saves
-            //Check if newly selected creature has a saving throw to make at the start of its turn
 
+            decrementDuration(thisGuy.StatusEffects);
+
+            //Progess the turn to the next creature
+            try
+            {
+                creatureListBox.SelectedIndex += 1;
+                thisGuy = (Creature)creatureListBox.SelectedItem;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                creatureListBox.SelectedIndex = 0;
+                nextRound_Click(sender, e);
+            }
+
+            //Use a try/catch to set the index back to zero if it goes out of range
+            //Search the new creature's status effect list and compile its SoT saves
+            saves = "";
+            saves = findSoTSaves(thisGuy.StatusEffects);
+
+            //If newly selected creature has a saving throw to make at the start of its turn, display alert
+            if(saves != "")
+            {
+                MessageBox.Show($"{thisGuy.GetName()} needs to make the following saving throw(s):\n" + saves);
+            }
         }
 
         private string findEoTSaves(List<StatusEffect> effects)
@@ -1024,6 +1045,26 @@ namespace GroupProject
                 { saveList += $"{effect.Name}: DC {effect.saveDC} {effect.saveType} Save\n"; }
             }
             return saveList;
+        }
+
+        private string findSoTSaves(List<StatusEffect> effects)
+        {
+            string saveList = "";
+            foreach(StatusEffect effect in effects)
+            {
+                if (effect.StartOfTurn == true)
+                { saveList += $"{effect.Name}: DC {effect.saveDC} {effect.saveType} Save\n"; }
+            }
+            return saveList;
+        }
+
+        private void decrementDuration(List<StatusEffect> effects)
+        {
+            for(int i = 0; i < effects.Count; i++)
+            {
+                effects[i].Duration -= 1;
+            }
+            effects.RemoveAll(effect =>  effect.Duration == 0);
         }
     }
 }

--- a/GroupProject/HPForm.cs
+++ b/GroupProject/HPForm.cs
@@ -54,6 +54,12 @@ namespace GroupProject
                     {
                         selectedCreature.SetTempHP(selectedCreature.GetTempHP() - healthChange);
                     }
+
+                    //Call for saving throws that activate on damage
+                    string saves = "";
+                    saves = findOnDmgSaves(selectedCreature.StatusEffects);
+                    if (saves != "")
+                    { MessageBox.Show($"{selectedCreature.GetName()} needs to make the following saving throw(s):\n" + saves); }
                 }
             }
             else
@@ -89,6 +95,16 @@ namespace GroupProject
                 button1_Click(sender, e);
 
             }
+        }
+        private string findOnDmgSaves(List<StatusEffect> effects)
+        {
+            string saveList = "";
+            foreach (StatusEffect effect in effects)
+            {
+                if (effect.WhenDamaged == true)
+                { saveList += $"{effect.Name}: DC {effect.saveDC} {effect.saveType} Save\n"; }
+            }
+            return saveList;
         }
     }
 }

--- a/GroupProject/class_declarations.cs
+++ b/GroupProject/class_declarations.cs
@@ -209,7 +209,7 @@ namespace GroupProject
         private string OtherEffects = "";
 
         //Duration in rounds
-        private byte Duration = 0;
+        public byte Duration = 0;
 
         //Type of Saving throw
         public string saveType = "";


### PR DESCRIPTION
Made initiative increase the round counter at the top when it returns to the top of the turn order

Made a prompt request to make saving throws at the end of a creatures turn

Made a prompt request to make saving throws at the start of the next creature's turn, after the last creature's EoT save message is exited

Made duration of status effects count down at the end of the creature's turn (made Duration public to do this).

Made Status Effect Maker have Duration default to 1 and Save DC default to 10